### PR TITLE
[Unity3D-sdk] Remove dependency on TextMeshPro from ugui/UnityNode.cs

### DIFF
--- a/Unity3D/ugui/UnityNode.cs
+++ b/Unity3D/ugui/UnityNode.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using UnityEngine.UI;
 using UnityEngine;
-using TMPro;
 
 
 namespace Poco
@@ -27,8 +26,6 @@ namespace Poco
             { "Selectable", "Selectable" },
             { "Camera", "Camera" },
             { "RectTransform", "Node" },
-            { "TextMeshProUGUI","TMPROUGUI" },
-            { "TMP_Text","TMPRO" },
         };
         public static string DefaultTypeName = "GameObject";
         private GameObject gameObject;
@@ -215,16 +212,6 @@ namespace Poco
 
         private string GameObjectText()
         {
-            TMP_Text tmpText = gameObject.GetComponent<TMP_Text>();
-            if (tmpText)
-            {
-                return tmpText.GetParsedText();
-            }
-            TextMeshProUGUI tmpUIText = gameObject.GetComponent<TextMeshProUGUI>();
-            if (tmpUIText)
-            {
-                return tmpUIText.GetParsedText();
-            }
             Text text = gameObject.GetComponent<Text>();
             return text ? text.text : null;
         }


### PR DESCRIPTION
Documentation in README says that folder 'ugui' should be chosen when target project uses UnityEngine.UI without TextMeshPro. But at the moment ugui/UnityNode.cs is not working without TextMeshPro. These changes fix it.

The commit actually roll back the changes made in commit 90376b987c90e0671c4c42bf9796d116484befbd last year. Probably, they was forgotten to roll back when TextMeshPro support was split to separate folder 'uguiWithTMPro'.