### PR TITLE
[Unity3D-sdk] Remove null propagation for C# 4.0

### DIFF
--- a/Unity3D/PocoManager.cs
+++ b/Unity3D/PocoManager.cs
@@ -152,7 +152,11 @@ public class PocoManager : MonoBehaviour
     public void stopListening()
     {
         mRunning = false;
-        server?.Stop();
+        var server = this.server;
+        if (server != null)
+        {
+            server.Stop();
+        }
     }
 
     [RPC]


### PR DESCRIPTION
Null propagation operator was released in C# 6.0. Older versions of Unity use C# 4.0 which doesn't have null propagation operator. This leads to errors like this:

```Assets/PocoSDK/PocoManager.cs(155,16): error CS1525: Unexpected symbol `.', expecting `[', or `identifier'```;

```<Assembly-CSharp>\Assets\PocoSDK\PocoManager.cs:5345 Feature 'null propagating operator' is not available. Please use language version 6.0 or greater.```

Documentation in README says that Poco-SDK supports Unity3D version 4 & 5 and above. To do this we should replace null propagation operator with the equivalent C# 4.0 code. This commit does it.