### PR TITLE
[Unity3D-sdk] No ConcurrentDictionary duplicates

### DIFF
--- a/Unity3D/ConcurrentDictionary.cs
+++ b/Unity3D/ConcurrentDictionary.cs
@@ -1,4 +1,4 @@
-#if !UNITY_WSA
+#if !UNITY_5_6_OR_NEWER || NET_2_0 || NET_2_0_SUBSET
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Threading;
 
-namespace TcpServer
+namespace System.Collections.Concurrent
 {
 
     /// <summary>

--- a/Unity3D/PocoManager.cs
+++ b/Unity3D/PocoManager.cs
@@ -2,6 +2,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Poco;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;

--- a/Unity3D/TcpServer.cs
+++ b/Unity3D/TcpServer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;


### PR DESCRIPTION
ConcurrentDictionary is released in .NET 4 and it is present in modern Unity API compatibility levels: .NET 4.x and .NET Standard 2.x. It's missed in legacy API compatibility levels: .NET 2.0 and .NET 2.0 Subset.

This commit proposes to add custom implementation of ConcurrentDictionary for legacy API compatibility levels, and use the existing ConcurrentDictionary for modern API compatibility levels.

I also remove the usage of define UNITY_WSA, because it only produces compile errors when build WSA, and because Poco-SDK doesn't build to WSA at all (due to System.Net.Sockets cannot be used for WSA, so TcpServer cannot be compiled).