### PR TITLE
Add handling of functions for Unity method invocations

### DIFF
--- a/Unity3D/PocoListenerUtils.cs
+++ b/Unity3D/PocoListenerUtils.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using UnityEngine;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+public static class PocoListenerUtils
+{
+    public static void SubscribePocoListeners(RPCParser rpc, PocoListenersBase listeners)
+    {
+        var methods = listeners.GetType()
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance);
+
+        var uniqueListeners = new HashSet<string>();
+
+        foreach (var method in methods)
+        {
+            var attribute = method.GetCustomAttribute<PocoMethodAttribute>();
+
+            if (attribute != null)
+            {
+                rpc.addListener(listeners, attribute.Name, method);
+
+                if (uniqueListeners.Add(attribute.Name) == false)
+                {
+                    Debug.LogError($"Attempt to add non-unique Poco listener: `{attribute.Name}`, " +
+                                   $"please check attributes of listeners at `{listeners.GetType().Name}`");
+                }
+            }
+        }
+    }
+
+    public static object HandleInvocation(
+        Dictionary<string, (object instance, MethodInfo method)> listeners,
+        Dictionary<string, object> data)
+    {
+        if (listeners == null)
+        {
+            throw new ArgumentNullException(
+                nameof(listeners),
+                "To use `poco.invoke()`, please assign object " +
+                $"of class derived from {nameof(PocoListenersBase)} " +
+                $"to field at `{nameof(PocoManager)}`");
+        }
+
+        var paramsObject = (JObject)data["params"];
+
+        var listener = paramsObject["listener"].ToObject<string>();
+
+        if (listeners.TryGetValue(listener, out var listenerPair) == false)
+        {
+            throw new NotImplementedException(
+                $"Listener method for `{listener}` " +
+                $"marked with `{nameof(PocoMethodAttribute)}` was not found " +
+                $"at `{listeners.GetType().Name}`");
+        }
+
+        var (instance, method) = listenerPair;
+
+        var args = GetInvocationArgs(paramsObject, method);
+
+        var result = method.Invoke(instance, args);
+
+        return result;
+    }
+
+    private static object[] GetInvocationArgs(JObject paramsObject, MethodInfo method)
+    {
+        var parameters = method.GetParameters();
+
+        if (paramsObject.TryGetValue("data", out var data) == false)
+        {
+            if (parameters.Length > 0)
+            {
+                throw new ArgumentException(
+                    $"Signature mismatch of method `{method}`: " +
+                    "expected 0 arguments in listener, " +
+                    $"received {parameters.Length} arguments");
+            }
+
+            return Array.Empty<object>();
+        }
+
+        var args = new List<object>();
+
+        var remainingArgNames = new HashSet<string>(data.ToObject<Dictionary<string, object>>().Keys);
+
+        foreach (var parameter in parameters)
+        {
+            var parameterName = parameter.Name;
+
+            var argToken = data[parameterName];
+
+            if (argToken == null)
+            {
+                throw new ArgumentException(
+                    $"Signature mismatch of method `{method}`: " +
+                    $"excess parameter `{parameterName}` in listener");
+            }
+
+            try
+            {
+                var argValue = argToken.ToObject(parameter.ParameterType);
+                args.Add(argValue);
+                remainingArgNames.Remove(parameterName);
+            }
+            catch (JsonReaderException exception)
+            {
+                throw new ArgumentException(
+                    $"Signature mismatch of method `{method}`: " +
+                    $"parameter `{parameterName}` type mismatch: " +
+                    $"tried to parse received value `{argToken}`, " +
+                    $"with type `{parameter.ParameterType.Name}` at listener",
+                    exception);
+            }
+        }
+
+        if (remainingArgNames.Count > 0)
+        {
+            throw new ArgumentException(
+                $"Signature mismatch of method `{method}`: " +
+                $"missing parameters in listener: `{string.Join(", ", remainingArgNames)}`");
+        }
+
+        return args.ToArray();
+    }
+}

--- a/Unity3D/PocoListenersBase.cs
+++ b/Unity3D/PocoListenersBase.cs
@@ -1,0 +1,3 @@
+using UnityEngine;
+
+public class PocoListenersBase : MonoBehaviour { }

--- a/Unity3D/PocoManager.cs
+++ b/Unity3D/PocoManager.cs
@@ -14,6 +14,8 @@ using Debug = UnityEngine.Debug;
 
 public class PocoManager : MonoBehaviour
 {
+    public event Action<string> MessageReceived;
+
     public const int versionCode = 6;
     public int port = 5001;
     private bool mRunning;
@@ -50,6 +52,7 @@ public class PocoManager : MonoBehaviour
         rpc.addRpcMethod("Dump", Dump);
         rpc.addRpcMethod("GetDebugProfilingData", GetDebugProfilingData);
         rpc.addRpcMethod("SetText", SetText);
+        rpc.addRpcMethod("SendMessage", SendMessage);
 
         rpc.addRpcMethod("GetSDKVersion", GetSDKVersion);
 
@@ -174,6 +177,21 @@ public class PocoManager : MonoBehaviour
             }
         }
         return false;
+    }
+
+    [RPC]
+    private object SendMessage(List<object> param)
+    {
+        if (MessageReceived == null)
+        {
+            return false;
+        }
+
+        var textVal = param[0] as string;
+
+        MessageReceived.Invoke(textVal);
+
+        return true;
     }
 
     [RPC]

--- a/Unity3D/PocoMethodAttribute.cs
+++ b/Unity3D/PocoMethodAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+
+public sealed class PocoMethodAttribute : Attribute
+{
+    public string Name { get; private set; }
+
+    public PocoMethodAttribute(string name)
+    {
+        Name = name;
+    }
+}


### PR DESCRIPTION
# Changes
- Add `MessageReceived` public event for handling simple calls with single `string` argument
- Add `HandleInvocation()` private utility method for handling calls with custom arguments

# Example

Here is example usage of `UnityPoco.invoke()`

## Poco-side

```python
poco = UnityPoco()
poco.invoke(listener="say_hello", name="anonymous", year=2024)
```

## Unity-side

1. Derive some new class from `PocoListenerBase`
2. Add method:

   ```csharp
   [PocoMethod("say_hello")]
   public void SayHello(string name, int year)
   {
       Debug.Log("Hi, ${name}! {year} is coming soon!");
   }
   ```

3. Add reference at `PocoManager` to ancestor of `PocoListenerBase`

# Dependencies
Depends on https://github.com/AirtestProject/Poco/pull/607